### PR TITLE
Fix loading plugins when multiple instances are used on the same page

### DIFF
--- a/Chart.php
+++ b/Chart.php
@@ -25,6 +25,8 @@ class Chart extends Widget
 
 	public $excanvas = false;
 
+	private static $loadedPlugins = [];
+
 	/**
 	 * @var string the name of the container element that contains the progress bar. Defaults to 'div'.
 	 */
@@ -61,16 +63,18 @@ class Chart extends Widget
 			ChartAsset::$extra_js[] = defined('YII_DEBUG') && YII_DEBUG ? 'excanvas.js' : 'excanvas.min.js';
 		}
 
+		$asset = ChartAsset::register($view);
+
 		if ($this->plugins && is_array($this->plugins)) {
 			foreach ($this->plugins as $plugin_code) {
 				$plugin_jsname = Plugin::getFilename($plugin_code);
-				if ($plugin_jsname) {
-					ChartAsset::$extra_js[] = $plugin_jsname;
+
+				if ($plugin_jsname && !in_array($plugin_jsname, self::$loadedPlugins)) {
+					self::$loadedPlugins[] = $plugin_jsname;
+					$view->registerJsFile($asset->baseUrl . '/' . $plugin_jsname, ['depends' => ChartAsset::className()]);
 				}
 			}
 		}
-
-		ChartAsset::register($view);
 
 		$flotdata    = Json::encode($this->data);
 		$flotoptions = Json::encode($this->options);

--- a/Chart.php
+++ b/Chart.php
@@ -3,7 +3,7 @@
  * @author Bogdan Burim <bgdn2007@ukr.net> 
  */
 
-namespace bburim\flot;
+namespace machour\flot;
 
 use Yii;
 use yii\base\Model;

--- a/ChartAsset.php
+++ b/ChartAsset.php
@@ -11,14 +11,8 @@ use yii;
 class ChartAsset extends AssetBundle
 {
 
-	public static $extra_js = [];
-
 	public function init() {
 		Yii::setAlias('@flot', __DIR__);
-
-		foreach (static::$extra_js as $js_file) {
-			$this->js[]= $js_file;
-		}
 
 		return parent::init();
 	}

--- a/ChartAsset.php
+++ b/ChartAsset.php
@@ -3,7 +3,7 @@
  * @author Bogdan Burim <bgdn2007@ukr.net> 
  */
 
-namespace bburim\flot;
+namespace machour\flot;
 
 use yii\web\AssetBundle;
 use yii;

--- a/Plugin.php
+++ b/Plugin.php
@@ -3,7 +3,7 @@
  * @author Bogdan Burim <bgdn2007@ukr.net> 
  */
 
-namespace bburim\flot;
+namespace machour\flot;
 
 class Plugin
 {

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ It is actually a wrapper for jQuery Flot Charts library.
 
 If you want to learn more about Flot options and documentation, please visit http://www.flotcharts.org/
 
+IMPORTANT
+===
+
+This is a temporary repository while waiting for this PR to be applied to bburim/flot
+It WILL be deleted soon (hopefully)
 
 Installation
 ===
@@ -20,7 +25,7 @@ Extension in the list of Composer packages: https://packagist.org/packages/bburi
 
 Installation command:
 
-    php composer.phar require "bburim/flot"
+    php composer.phar require "machour/yii2-jquery-flot"
 
 
 Basic Usage

--- a/assets.php
+++ b/assets.php
@@ -1,5 +1,5 @@
 <?php
 
-return array(
-	bburim\flot\ChartAsset::className(), 
-);
+return [
+	machour\flot\ChartAsset::className(), 
+];

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type": "yii2-extension",
 	"license": "GNU GENERAL PUBLIC LICENSE",
 	"support": {
-		"source": "https://github.com/bburim/flot"
+		"source": "https://github.com/machour/yii2-jquery-flot"
 	},
 	"authors": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,17 @@
 	"require": {
 		"yiisoft/yii2": "*"
 	},
-	"autoload": {
-		"psr-0": { "machour\\flot\\": "" }
-	}
+    "autoload": {
+        "psr-4": {
+            "machour\\flot\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        },
+        "asset-installer-paths": {
+            "bower-asset-library": "vendor/bower"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,5 @@
 	"autoload": {
 		"psr-0": { "machour\\flot\\": "" }
 	},
-	"target-dir": "machour/flot"
+	"target-dir": "machour/yii2-jquery-flot"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "bburim/flot",
+	"name": "machour/yii2-jquery-flot",
 	"description": "jQuery Flot Charts extension for the Yii 2 framework",
 	"keywords": ["yii", "flot", "jquery", "chart"],
 	"type": "yii2-extension",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,5 @@
 	},
 	"autoload": {
 		"psr-0": { "machour\\flot\\": "" }
-	},
-	"target-dir": "machour/yii2-jquery-flot"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"yiisoft/yii2": "*"
 	},
 	"autoload": {
-		"psr-0": { "bburim\\flot\\": "" }
+		"psr-0": { "machour\\flot\\": "" }
 	},
-	"target-dir": "bburim/flot"
+	"target-dir": "machour/flot"
 }


### PR DESCRIPTION
Hi,

There was a problem, described in issue #4, which made the plugins not being loaded for the subsequent widget usage on the same page, as they were only taken in account for the first widget usage.

This PR fixes that problem :)
